### PR TITLE
adds lock guard to protect requestQUeue

### DIFF
--- a/LibCamera.cpp
+++ b/LibCamera.cpp
@@ -174,6 +174,7 @@ void LibCamera::requestComplete(Request *request) {
 }
 
 void LibCamera::processRequest(Request *request) {
+    std::lock_guard<std::mutex> lock(free_requests_mutex_);
     requestQueue.push(request);
 }
 


### PR DESCRIPTION
This PR is intended to fix a data issue caused by concurrent access to  `LibCamera::requestQueue`.

Note that `LibCamera::processRequest()` is asynchronously called here:
```c++
camera_->requestCompleted.connect(this, &LibCamera::requestComplete);
```
resulting in:
```c++
void LibCamera::processRequest(Request *request) {
    requestQueue.push(request);
}
```
without locking. At the same time, the main thread calls:
```c++
bool LibCamera::readFrame(LibcameraOutData *frameData){
    std::lock_guard<std::mutex> lock(free_requests_mutex_);
    // ...
        Request *request = this->requestQueue.front();
```
This scenario sometimes results in a segmentation fault when the `request` object is further consumed, causing the process to exit with SEGV signal.